### PR TITLE
feat(tools): hide the function tool from the public tools page

### DIFF
--- a/src/modules/tools/ToolsList.tsx
+++ b/src/modules/tools/ToolsList.tsx
@@ -55,7 +55,7 @@ export function ToolsList({ type }: Props) {
     type:
       type === 'user'
         ? ['user']
-        : ['code_interpreter', 'file_search', 'function', 'system'],
+        : ['code_interpreter', 'file_search', 'system'],
     limit: PAGE_SIZE,
     ...order,
     search: search.length ? search : undefined,


### PR DESCRIPTION
Refs: https://github.ibm.com/Incubation/bee-ui/issues/637