### PR TITLE
fix(assistant-builder): starter questions style

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "lint-staged": "^15.2.2",
     "prettier": "^3.2.5",
     "release-it": "^17.10.0",
-    "sass": "^1.72.0",
+    "sass": "^1.77.4",
     "stylelint": "^16.3.1",
     "stylelint-config-css-modules": "^4.4.0",
     "stylelint-config-recommended-scss": "^14.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,7 +282,7 @@ importers:
         specifier: ^17.10.0
         version: 17.10.0(typescript@5.6.3)
       sass:
-        specifier: ^1.72.0
+        specifier: ^1.77.4
         version: 1.80.5
       stylelint:
         specifier: ^16.3.1
@@ -11603,7 +11603,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.2(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -11638,7 +11638,7 @@ snapshots:
       is-bun-module: 1.2.1
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
@@ -11656,7 +11656,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8

--- a/src/components/TextAreaAutoHeight/TextAreaAutoHeight.module.scss
+++ b/src/components/TextAreaAutoHeight/TextAreaAutoHeight.module.scss
@@ -18,87 +18,85 @@
 
 $line-size: (21 / 14) * 0.875rem;
 
-@layer components {
-  .root {
-    /* easy way to plop the elements on top of each other and have them both sized based on the tallest one's height */
-    display: grid;
-    position: relative;
+.root {
+  /* easy way to plop the elements on top of each other and have them both sized based on the tallest one's height */
+  display: grid;
+  position: relative;
 
+  &::after {
+    /* Note the weird space! Needed to preventy jumpy behavior */
+    content: attr(data-replicated-value) ' ';
+    max-block-size: calc((var(--max-rows) * $line-size) + (2 * $spacing-04));
+
+    /* This is how textarea text behaves */
+    white-space: pre-wrap;
+
+    /* Hidden from view, clicks, and screen readers */
+    visibility: hidden;
+  }
+
+  /* Turn off automatic resize feature after the height is manually modified */
+  &.resized {
     &::after {
-      /* Note the weird space! Needed to preventy jumpy behavior */
-      content: attr(data-replicated-value) ' ';
-      max-block-size: calc((var(--max-rows) * $line-size) + (2 * $spacing-04));
-
-      /* This is how textarea text behaves */
-      white-space: pre-wrap;
-
-      /* Hidden from view, clicks, and screen readers */
-      visibility: hidden;
-    }
-
-    /* Turn off automatic resize feature after the height is manually modified */
-    &.resized {
-      &::after {
-        display: none;
-      }
-    }
-
-    > textarea {
-      /* After user resizes, it ruins the auto sizing */
-      resize: none;
-      /* Hide FF scrollbar on growth */
-      overflow: hidden;
-      max-block-size: var(--max-block-size);
-      &::placeholder {
-        color: $text-placeholder;
-      }
-    }
-
-    > textarea,
-    &::after {
-      /* Place on top of each other */
-      grid-area: 1 / 1 / 2 / 2;
-
-      @include type-style(body-02);
-      padding: $spacing-04;
-      border: 0;
+      display: none;
     }
   }
 
-  .resizeHandle {
-    position: absolute;
-    inset-block-end: 0;
-    inset-inline-end: 0;
-    z-index: 1;
-    border: none;
-    background-color: transparent;
-    block-size: $spacing-05;
-    inline-size: $spacing-05;
-    padding: $spacing-02;
-    display: flex;
-    align-items: flex-end;
-    gap: 1px;
-    cursor: ns-resize;
-    color: $text-secondary;
+  > textarea {
+    /* After user resizes, it ruins the auto sizing */
+    resize: none;
+    /* Hide FF scrollbar on growth */
+    overflow: hidden;
+    max-block-size: var(--max-block-size);
+    &::placeholder {
+      color: $text-placeholder;
+    }
+  }
 
-    .resizeHandleContent {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      transform: rotate(-45deg);
-      gap: 2px;
-      &::after,
-      &::before {
-        content: '';
-        display: block;
-        inline-size: rem(12px);
-        block-size: 1px;
-        transform-origin: center;
-        background-color: currentColor;
-      }
-      &::after {
-        inline-size: rem(5px);
-      }
+  > textarea,
+  &::after {
+    /* Place on top of each other */
+    grid-area: 1 / 1 / 2 / 2;
+
+    @include type-style(body-02);
+    padding: $spacing-04;
+    border: 0;
+  }
+}
+
+.resizeHandle {
+  position: absolute;
+  inset-block-end: 0;
+  inset-inline-end: 0;
+  z-index: 1;
+  border: none;
+  background-color: transparent;
+  block-size: $spacing-05;
+  inline-size: $spacing-05;
+  padding: $spacing-02;
+  display: flex;
+  align-items: flex-end;
+  gap: 1px;
+  cursor: ns-resize;
+  color: $text-secondary;
+
+  .resizeHandleContent {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    transform: rotate(-45deg);
+    gap: 2px;
+    &::after,
+    &::before {
+      content: '';
+      display: block;
+      inline-size: rem(12px);
+      block-size: 1px;
+      transform-origin: center;
+      background-color: currentColor;
+    }
+    &::after {
+      inline-size: rem(5px);
     }
   }
 }

--- a/src/components/TextAreaAutoHeight/TextAreaAutoHeight.module.scss
+++ b/src/components/TextAreaAutoHeight/TextAreaAutoHeight.module.scss
@@ -18,85 +18,87 @@
 
 $line-size: (21 / 14) * 0.875rem;
 
-.root {
-  /* easy way to plop the elements on top of each other and have them both sized based on the tallest one's height */
-  display: grid;
-  position: relative;
+@layer components {
+  .root {
+    /* easy way to plop the elements on top of each other and have them both sized based on the tallest one's height */
+    display: grid;
+    position: relative;
 
-  &::after {
-    /* Note the weird space! Needed to preventy jumpy behavior */
-    content: attr(data-replicated-value) ' ';
-    max-block-size: calc((var(--max-rows) * $line-size) + (2 * $spacing-04));
-
-    /* This is how textarea text behaves */
-    white-space: pre-wrap;
-
-    /* Hidden from view, clicks, and screen readers */
-    visibility: hidden;
-  }
-
-  /* Turn off automatic resize feature after the height is manually modified */
-  &.resized {
     &::after {
-      display: none;
+      /* Note the weird space! Needed to preventy jumpy behavior */
+      content: attr(data-replicated-value) ' ';
+      max-block-size: calc((var(--max-rows) * $line-size) + (2 * $spacing-04));
+
+      /* This is how textarea text behaves */
+      white-space: pre-wrap;
+
+      /* Hidden from view, clicks, and screen readers */
+      visibility: hidden;
+    }
+
+    /* Turn off automatic resize feature after the height is manually modified */
+    &.resized {
+      &::after {
+        display: none;
+      }
+    }
+
+    > textarea {
+      /* After user resizes, it ruins the auto sizing */
+      resize: none;
+      /* Hide FF scrollbar on growth */
+      overflow: hidden;
+      max-block-size: var(--max-block-size);
+      &::placeholder {
+        color: $text-placeholder;
+      }
+    }
+
+    > textarea,
+    &::after {
+      /* Place on top of each other */
+      grid-area: 1 / 1 / 2 / 2;
+
+      @include type-style(body-02);
+      padding: $spacing-04;
+      border: 0;
     }
   }
 
-  > textarea {
-    /* After user resizes, it ruins the auto sizing */
-    resize: none;
-    /* Hide FF scrollbar on growth */
-    overflow: hidden;
-    max-block-size: var(--max-block-size);
-    &::placeholder {
-      color: $text-placeholder;
-    }
-  }
-
-  > textarea,
-  &::after {
-    /* Place on top of each other */
-    grid-area: 1 / 1 / 2 / 2;
-
-    @include type-style(body-02);
-    padding: $spacing-04;
-    border: 0;
-  }
-}
-
-.resizeHandle {
-  position: absolute;
-  inset-block-end: 0;
-  inset-inline-end: 0;
-  z-index: 1;
-  border: none;
-  background-color: transparent;
-  block-size: $spacing-05;
-  inline-size: $spacing-05;
-  padding: $spacing-02;
-  display: flex;
-  align-items: flex-end;
-  gap: 1px;
-  cursor: ns-resize;
-  color: $text-secondary;
-
-  .resizeHandleContent {
+  .resizeHandle {
+    position: absolute;
+    inset-block-end: 0;
+    inset-inline-end: 0;
+    z-index: 1;
+    border: none;
+    background-color: transparent;
+    block-size: $spacing-05;
+    inline-size: $spacing-05;
+    padding: $spacing-02;
     display: flex;
-    flex-direction: column;
-    align-items: center;
-    transform: rotate(-45deg);
-    gap: 2px;
-    &::after,
-    &::before {
-      content: '';
-      display: block;
-      inline-size: rem(12px);
-      block-size: 1px;
-      transform-origin: center;
-      background-color: currentColor;
-    }
-    &::after {
-      inline-size: rem(5px);
+    align-items: flex-end;
+    gap: 1px;
+    cursor: ns-resize;
+    color: $text-secondary;
+
+    .resizeHandleContent {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      transform: rotate(-45deg);
+      gap: 2px;
+      &::after,
+      &::before {
+        content: '';
+        display: block;
+        inline-size: rem(12px);
+        block-size: 1px;
+        transform-origin: center;
+        background-color: currentColor;
+      }
+      &::after {
+        inline-size: rem(5px);
+      }
     }
   }
 }

--- a/src/modules/assistants/builder/StarterQuestionsTextArea.module.scss
+++ b/src/modules/assistants/builder/StarterQuestionsTextArea.module.scss
@@ -16,22 +16,11 @@
 
 @use 'styles/common' as *;
 
-.root {
-  :global(.#{$prefix}--label) {
-    margin-block-end: $spacing-03;
-  }
-}
-
-.addHolder {
-  display: flex;
-  align-items: stretch;
-}
-
-.textarea {
-  position: relative;
+@mixin textarea-auto-height() {
   flex-grow: 1;
   z-index: 1;
   min-inline-size: 0;
+
   &::after,
   > textarea {
     @include type-style(body-01);
@@ -51,15 +40,28 @@
   }
 }
 
-.addTextarea {
-  &::after,
-  > textarea {
-    border-start-end-radius: 0;
-    border-end-end-radius: 0;
-    border: 1px solid $border-subtle-00;
+.root {
+  :global(.#{$prefix}--label) {
+    margin-block-end: $spacing-03;
   }
-  > textarea {
-    background-color: transparent;
+}
+
+.addHolder {
+  display: flex;
+  align-items: stretch;
+
+  > .addTextarea {
+    @include textarea-auto-height();
+
+    &::after,
+    > textarea {
+      border-start-end-radius: 0;
+      border-end-end-radius: 0;
+      border: 1px solid $border-subtle-00;
+    }
+    > textarea {
+      background-color: transparent;
+    }
   }
 }
 
@@ -86,7 +88,6 @@
     color: $text-dark;
     &:hover {
       background-color: $border-subtle-00;
-      color: $text-muted;
     }
     &:disabled {
       color: $border-disabled;
@@ -109,28 +110,30 @@
 
 .item {
   position: relative;
-}
 
-.itemTextarea {
-  &::after,
-  > textarea {
-    border: 1px solid $border-subtle-01;
-    padding-inline-end: rem(47px);
-  }
-  > textarea {
-    background-color: $border-subtle-01;
-  }
-}
+  > .itemTextarea {
+    @include textarea-auto-height();
 
-.readOnlyTextarea {
-  &::after,
-  > textarea {
-    padding-inline-end: rem(15px);
-  }
-  > textarea {
-    &:active,
-    &:focus {
-      outline: none;
+    &::after,
+    > textarea {
+      border: 1px solid $border-subtle-01;
+      padding-inline-end: rem(47px);
+    }
+    > textarea {
+      background-color: $border-subtle-01;
+    }
+
+    &.readOnlyTextarea {
+      &::after,
+      > textarea {
+        padding-inline-end: rem(15px);
+      }
+      > textarea {
+        &:active,
+        &:focus {
+          outline: none;
+        }
+      }
     }
   }
 }

--- a/src/modules/assistants/builder/StarterQuestionsTextArea.tsx
+++ b/src/modules/assistants/builder/StarterQuestionsTextArea.tsx
@@ -122,7 +122,7 @@ export function StarterQuestionsTextArea() {
       {!hasMaxQuestions && !isProjectReadOnly && (
         <div className={classes.addHolder}>
           <TextAreaAutoHeight
-            className={clsx(classes.textarea, classes.addTextarea)}
+            className={classes.addTextarea}
             placeholder="Type and add a question that users can select at the start of a new session"
             rows={1}
             maxLength={MAX_QUESTION_LENGTH}
@@ -148,7 +148,7 @@ export function StarterQuestionsTextArea() {
           {questions.map(({ id, question }) => (
             <li key={id} className={classes.item}>
               <TextAreaAutoHeight
-                className={clsx(classes.textarea, classes.itemTextarea, {
+                className={clsx(classes.itemTextarea, {
                   [classes.readOnlyTextarea]: isProjectReadOnly,
                 })}
                 rows={1}


### PR DESCRIPTION
~~Experimental way of solving wrong css modules order in Next.js build.~~

This issue cannot be resolved using CSS layers, which would have been the preferred approach, as Carbon is not ready for that usage. The final solution involves using stronger selectors to ensure style prioritization.
