### PR TITLE
fix(apps): use the last app code block in message

### DIFF
--- a/src/modules/apps/utils.ts
+++ b/src/modules/apps/utils.ts
@@ -15,7 +15,7 @@
  */
 
 export function extractCodeFromMessageContent(content: string) {
-  return content.match(/```python-app\n([\s\S]*?)```/)?.at(-1);
+  return [...content.matchAll(/```python-app\n([\s\S]*?)```/g)].at(-1)?.at(-1);
 }
 
 export function extractAppMetadataFromStreamlitCode(code: string) {


### PR DESCRIPTION
The LLM sometimes corrects itself and writes another app code block. This ensures that the last one in the message is used.