### PR TITLE
feat: prelaunch qa updates

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -90,7 +90,7 @@ const getCspHeader = (nonce: string) => {
       process.env.NODE_ENV === 'production' ? '' : `'unsafe-eval'`
     };
     style-src 'self' 'nonce-${nonce}';
-    img-src *;
+    img-src * blob: data: www.ibm.com/;
     font-src 'self';
     object-src 'none';
     frame-src ${USERCONTENT_SITE_URL};

--- a/src/modules/apps/builder/AppBuilderProvider.tsx
+++ b/src/modules/apps/builder/AppBuilderProvider.tsx
@@ -62,7 +62,7 @@ export function AppBuilderProvider({
       null,
   );
 
-  useOnboardingCompleted(isOnboarding ? 'apps' : null);
+  useOnboardingCompleted('apps');
 
   const apiValue = useMemo(
     () => ({

--- a/src/modules/apps/onboarding/AppsOnboardingModal.tsx
+++ b/src/modules/apps/onboarding/AppsOnboardingModal.tsx
@@ -49,7 +49,6 @@ export function AppsOnboardingModal({ ...props }: Props) {
         body: <AppsOnboardingIntro />,
         footerProps: {
           onNextClick: () => setStep(Steps.TEMPLATE_SELECTION),
-          nextButtonTitle: 'Start building',
         },
       };
       break;
@@ -68,6 +67,7 @@ export function AppsOnboardingModal({ ...props }: Props) {
               `/${project.id}/apps/builder?${ONBOARDING_PARAM}${selectedTemplate ? `&template=${selectedTemplate.key}` : ''}`,
             ),
           onBackClick: () => setStep(Steps.INTRO),
+          nextButtonTitle: 'Start building',
         },
       };
       break;
@@ -79,7 +79,6 @@ export function AppsOnboardingModal({ ...props }: Props) {
     <ModalControlProvider onRequestClose={noop}>
       <Modal
         {...props}
-        preventCloseOnClickOutside
         className={clsx(classes.root, classes[`step--${step}`])}
       >
         <ModalBody>{body}</ModalBody>

--- a/src/modules/apps/onboarding/OnboardingFooter.tsx
+++ b/src/modules/apps/onboarding/OnboardingFooter.tsx
@@ -18,7 +18,7 @@ import { Button } from '@carbon/react';
 import { ArrowRight } from '@carbon/react/icons';
 
 export function OnboardingModalFooter({
-  nextButtonTitle = 'Start building',
+  nextButtonTitle = 'Next',
   onNextClick,
   onBackClick,
 }: {

--- a/src/modules/chat/assistant-plan/PlanStep.tsx
+++ b/src/modules/chat/assistant-plan/PlanStep.tsx
@@ -111,9 +111,9 @@ export function PlanStep({ step, toolCall, allStepsDone }: Props) {
   });
   const ToolIcon = toolKey ? toolIcon : null;
 
-  const expandedStep = useExpandedStep();
+  const expandedState = useExpandedStep();
   const { setExpandedStep } = useExpandedStepActions();
-  const expanded = expandedStep === step.id;
+  const expanded = expandedState?.stepId === step.id;
 
   const toolApproval = (
     run?.status === 'requires_action' &&
@@ -160,8 +160,10 @@ export function PlanStep({ step, toolCall, allStepsDone }: Props) {
 
   const toggleExpand = useCallback(
     (forceOpen?: boolean) =>
-      setExpandedStep((expanded) =>
-        forceOpen || expanded !== step.id ? step.id : null,
+      setExpandedStep((value) =>
+        forceOpen || value?.stepId !== step.id
+          ? { stepId: step.id, initiator: 'user' }
+          : null,
       ),
     [setExpandedStep, step.id],
   );
@@ -173,7 +175,13 @@ export function PlanStep({ step, toolCall, allStepsDone }: Props) {
 
   useEffect(() => {
     if (toolApproval) {
-      setExpandedStep(step.id);
+      setExpandedStep({ stepId: step.id, initiator: 'approval' });
+    } else {
+      setExpandedStep((value) =>
+        value?.stepId === step.id && value.initiator === 'approval'
+          ? null
+          : value,
+      );
     }
   }, [toolApproval, step.id, setExpandedStep]);
 

--- a/src/modules/chat/assistant-plan/PlanWithSources.tsx
+++ b/src/modules/chat/assistant-plan/PlanWithSources.tsx
@@ -116,11 +116,12 @@ function PlanWithSourcesComponent({ message, inView }: Props) {
     setIsOpen(
       debugMode
         ? debugMode
-        : message.plan &&
+        : message.pending &&
+            message.plan &&
             ((message.plan.pending && !messageHasContent) ||
               (!message.plan.pending && messageHasContent)),
     );
-  }, [debugMode, message.plan, messageHasContent]);
+  }, [debugMode, message.pending, message.plan, messageHasContent]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -184,7 +185,8 @@ function PlanWithSourcesComponent({ message, inView }: Props) {
         <SourcesView
           sources={sources.map(({ steps, ...props }) => ({
             ...props,
-            filtered: !(expandedStep !== null) || steps.includes(expandedStep),
+            filtered:
+              !(expandedStep !== null) || steps.includes(expandedStep.stepId),
           }))}
           show={isOpen}
           enableFetch={enableFetch}

--- a/src/modules/chat/providers/ExpandedStepProvider.tsx
+++ b/src/modules/chat/providers/ExpandedStepProvider.tsx
@@ -27,10 +27,15 @@ import {
   useState,
 } from 'react';
 
-const ExpandedStepContext = createContext<string | null>(null);
+type ExpandedStepState = {
+  stepId: string;
+  initiator: 'approval' | 'user' | null;
+};
+
+const ExpandedStepContext = createContext<ExpandedStepState | null>(null);
 
 type ExpandedStepActionsContextValue = {
-  setExpandedStep: Dispatch<SetStateAction<string | null>>;
+  setExpandedStep: Dispatch<SetStateAction<ExpandedStepState | null>>;
 };
 
 const ExpandedStepActionsContext =
@@ -39,7 +44,9 @@ const ExpandedStepActionsContext =
   });
 
 export function ExpandedStepProvider({ children }: PropsWithChildren) {
-  const [expandedStep, setExpandedStep] = useState<string | null>(null);
+  const [expandedStep, setExpandedStep] = useState<ExpandedStepState | null>(
+    null,
+  );
 
   const stepsActions = useMemo(
     () => ({

--- a/src/modules/users/useOnboardingCompleted.ts
+++ b/src/modules/users/useOnboardingCompleted.ts
@@ -25,7 +25,7 @@ export function useOnboardingCompleted(section: OnboardingSection | null) {
   const userMetadata = useUserProfile((state) => state.metadata);
 
   useOnMount(() => {
-    if (section)
+    if (section && !userMetadata?.onboarding_section_completed_at?.[section])
       updateUserMutate({
         metadata: encodeMetadata<UserMetadata>({
           ...userMetadata,


### PR DESCRIPTION
https://github.com/i-am-bee/internal/issues/73

Handles:
- [Agent use] Collapse the plan once the user allows the tool or gets the answer
- [App builder - onboarding modal] Add ability to dismiss onboarding window (click background to close) and replace “Start building” by “Next”
- [App builder - template modal] Add ability to dismiss onboarding window (click background to close)
- [App builder - template modal] Add ability to dismiss onboarding window (click background to close)
- blobs in svgs blocked by csp