### PR TITLE
fix(apps): use a normal message for error fixing

### DIFF
--- a/src/modules/apps/builder/AppBuilder.tsx
+++ b/src/modules/apps/builder/AppBuilder.tsx
@@ -238,14 +238,11 @@ function AppBuilderContent() {
 
   const handleReportError = useCallback(
     async (errorText: string) => {
-      await createMessage(organization.id, project.id, thread!.id, {
-        role: 'user',
-        content: `I have encountered the following error:\n\n\`\`\`error\n${errorText}\n\`\`\``,
-        metadata: encodeMetadata<MessageMetadata>({ type: 'report-error' }),
-      });
-      await sendMessage(`Help me fix the attached error.`);
+      await sendMessage(
+        `I have encountered the following error:\n\n\`\`\`error\n${errorText}\n\`\`\`\n\nFix this error please.`,
+      );
     },
-    [organization, project, thread, sendMessage],
+    [sendMessage],
   );
 
   return (


### PR DESCRIPTION
`createMessage` wouldn't work in cases where there was no thread, like when the app was just opened for editing. `sendMessage` does not support metadata. This is a temporary solution that uses a single visible message for fixing errors until we have a more robust way present.